### PR TITLE
bump actions/checkout to v3

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/1-add-headers.yml
+++ b/.github/workflows/1-add-headers.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/2-add-an-image.yml
+++ b/.github/workflows/2-add-an-image.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/3-add-a-code-example.yml
+++ b/.github/workflows/3-add-a-code-example.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/4-make-a-task-list.yml
+++ b/.github/workflows/4-make-a-task-list.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 


### PR DESCRIPTION
### Why:

Closes https://github.com/skills/communicate-using-markdown/issues/21

### What's being changed:

* bump actions/checkout to v3

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] n/a For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
