### PR TITLE
Use quadruple backticks

### DIFF
--- a/.github/steps/3-add-a-code-example.md
+++ b/.github/steps/3-add-a-code-example.md
@@ -12,12 +12,12 @@ In addition to code blocks, some code blocks should be rendered differently depe
 
 ### Example
 
-<pre>
+````md
 ```
 $ git init
 Initialized empty Git repository in /Users/skills/Projects/recipe-repository/.git/
 ```
-</pre>
+````
 
 #### How it looks
 


### PR DESCRIPTION
No need to use `<pre>[code block]</pre>`

### Summary

You can display triple backticks in a fenced code block by wrapping them inside quadruple backticks.
See: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks

### Changes

- `<pre>` &rarr; ```` (quadruple backticks)
- `</pre>` &rarr; ```` (quadruple backticks)

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
