### PR TITLE
Confusing steps in 1-add-headers.md

### DIFF
--- a/.github/steps/1-add-headers.md
+++ b/.github/steps/1-add-headers.md
@@ -42,6 +42,8 @@ _Welcome to "Communicate using Markdown"! :wave:_
 1. Open the **pull requests** tab.
 1. Click **New pull request**, for the branches to compare, select `base: main` and `compare: start-markdown`.
 1. Click **Create pull request**.
+1. Give a title to your pull request, like **"My pull request"**.
+1. Click **Create pull request**.
 1. In this pull request, go to the **Files changed** tab. We made an empty file `index.md` for you.
 1. Select **Edit file** from the three dotted **...** menu in the upper right corner of the file view on `index.md`.
 1. On the **Edit file** tab, add a `#`, followed by a **space**, before any content you like to make it an H1 Header. You can add more headers, using one to six `#` characters followed by a **space**.


### PR DESCRIPTION
# The steps in 1-add-headers.md were a bit confusing regarding the PR process.

## Summary

In the instructions to create a pull request, there is only one step saying "Click **Create pull request**."

But there are two "**Create pull request**" buttons.

And something that make the process a bit more confusing for the learner is that when you click in the first Create pull request button:

===

![first-pr-btn](https://github.com/user-attachments/assets/84050df2-3984-4175-825f-8d10deb7e5b3)

===

You go to a page (Wrong page, you would need to click in the second **Create pull request** button to go to the right one.) that have a "files changed" field, and the file index.md:

===

![files-changed](https://github.com/user-attachments/assets/da63dbcc-8102-4582-b77f-b74b8a578f14)

===

Ok, it is not a tab (in the steps it is saying to click in a tab), but a learner without much experience, would think that it is the right one.

And the index.md present in that page is not editable yet, so, as pointed by [hadder94](https://github.com/hadder94), (in the issues page) when you click in the menu, the option to edit it grayed out.

## Changes

So, to solve this, i recommend putting something similar to what i did.

To make it very clear to the learner, that it is necessary to **create** a PR.

Giving the instructions to interact with the title of the PR and create it, clicking again in the "**Create pull request**" button:

===

![second-pr-btn](https://github.com/user-attachments/assets/b1399f19-2f49-488a-98e4-4163fec7e66d)

===

Related issues:

https://github.com/skills/communicate-using-markdown/issues/245#issue-2728353257
