### PR TITLE
Fix grammar in task list description

### DIFF
--- a/.github/steps/2-make-a-task-list.md
+++ b/.github/steps/2-make-a-task-list.md
@@ -36,7 +36,7 @@ A list is changed to ordered by using any number instead of the list character. 
 
 ### Task List
 
-A task list is extends the unordered list to use check boxes.
+A task list extends an unordered list to use checkboxes.
 Add empty brackets `[ ]` for incomplete tasks and filled brackets `[x]` for complete tasks. Note: The empty required space for empty brackets.
 
 ```md


### PR DESCRIPTION
Fix grammar in task list explanation.

Corrected "A task list is extends..." to "A task list extends...".