### PR TITLE
chore: bump copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ If the exercise isn't ready in 20 seconds:
 
 ---
 
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+&copy; 2026 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)


### PR DESCRIPTION
There have been 2 commits this year, so why not?