### PR TITLE
docs: fix grammar in task list explanation

### DIFF
--- a/.github/steps/2-make-a-task-list.md
+++ b/.github/steps/2-make-a-task-list.md
@@ -36,7 +36,7 @@ A list is changed to ordered by using any number instead of the list character. 
 
 ### Task List
 
-A task list is extends the unordered list to use check boxes.
+A task list extends the unordered list to use check boxes.
 Add empty brackets `[ ]` for incomplete tasks and filled brackets `[x]` for complete tasks. Note: The empty required space for empty brackets.
 
 ```md


### PR DESCRIPTION
### Summary
Fixes a grammatical error in the task list explanation.

The original sentence read:
> "A task list is extends the unordered list to use check boxes."

This pull request corrects the wording while preserving the original meaning.

### Changes
- Corrected the grammatical error in the task list explanation.
- No functional changes; documentation only.


Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).
