### PR TITLE
fix: typo in step 2

### DIFF
--- a/.github/steps/2-make-a-task-list.md
+++ b/.github/steps/2-make-a-task-list.md
@@ -36,7 +36,7 @@ A list is changed to ordered by using any number instead of the list character. 
 
 ### Task List
 
-A task list is extends the unordered list to use check boxes.
+A task list extends the unordered list to use check boxes.
 Add empty brackets `[ ]` for incomplete tasks and filled brackets `[x]` for complete tasks. Note: The empty required space for empty brackets.
 
 ```md


### PR DESCRIPTION
### Summary
Fix a grammatical error in the task list description section.

### Changes
Removes redundant "is" from the sentence describing task lists.

**Before:** "A task list is extends the unordered list to use check boxes."
**After:** "A task list extends the unordered list to use check boxes."

Closes:

### Task list
- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).